### PR TITLE
Fix #50

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## storr 1.1.1 (2017-08-14)
+
+* Use the full path so `storr`s still work when the the working directory changes.
+
 ## storr 1.1.0 (2017-05-05)
 
 * Support for using relational databases via DBI (SQLite, Postgres) #23 - MySQL and Microsoft SQL Server support is not implemented yet

--- a/R/driver_rds.R
+++ b/R/driver_rds.R
@@ -113,7 +113,7 @@ R6_driver_rds <- R6::R6Class(
       dir_create(file.path(path, "data"))
       dir_create(file.path(path, "keys"))
       dir_create(file.path(path, "config"))
-      self$path <- normalizePath(path)
+      self$path <- normalizePath(path, mustWork = TRUE)
 
       ## This is a bit of complicated dancing around to mantain
       ## backward compatibility while allowing better defaults in

--- a/R/driver_rds.R
+++ b/R/driver_rds.R
@@ -113,7 +113,7 @@ R6_driver_rds <- R6::R6Class(
       dir_create(file.path(path, "data"))
       dir_create(file.path(path, "keys"))
       dir_create(file.path(path, "config"))
-      self$path <- path
+      self$path <- normalizePath(path)
 
       ## This is a bit of complicated dancing around to mantain
       ## backward compatibility while allowing better defaults in

--- a/tests/testthat/test-driver-rds.R
+++ b/tests/testthat/test-driver-rds.R
@@ -235,7 +235,8 @@ test_that("change directories and access same storr", {
   expect_equal(x$list(), "a")
   subdir <- "subdir"
   dir.create(subdir)
-  setwd(subdir)
+  owd <- setwd(subdir)
+  on.exit(setwd(owd))
   expect_equal(x$list(), "a")
   setwd("..")
   unlink(subdir, recursive = TRUE)

--- a/tests/testthat/test-driver-rds.R
+++ b/tests/testthat/test-driver-rds.R
@@ -228,3 +228,16 @@ test_that("vectorised exists", {
   st$set("xx", 2)
   expect_equal(st$exists(c("x", "xx")), c(TRUE, TRUE))
 })
+
+test_that("change directories and access same storr", {
+  x <- storr_rds("my_storr")
+  x$set("a", 1)
+  expect_equal(x$list(), "a")
+  subdir <- "subdir"
+  dir.create(subdir)
+  setwd(subdir)
+  expect_equal(x$list(), "a")
+  setwd("..")
+  unlink(subdir, recursive = TRUE)
+  x$destroy()
+})


### PR DESCRIPTION
Use `normalilzePath()` to convert relative paths into full paths
when creating new `storr`s. Also add a test to the bottom of
`tests/testthat/test-driver-rds.R` to ensure the correct behavior.