### PR TITLE
Fix #52

### DIFF
--- a/tests/testthat/helper-storr.R
+++ b/tests/testthat/helper-storr.R
@@ -6,6 +6,14 @@ rand_str <- function(n = 16L, hex = TRUE) {
   }
 }
 
+can_use_redis <- function(){
+  redux_installed <- "redux" %in% .packages(TRUE)
+  if (!redux_installed){
+    return(FALSE)
+  }
+  redux::redis_available()
+}
+
 skip_long_test <- function() {
   if (identical(Sys.getenv("STORR_RUN_LONG_TESTS"), "true")) {
     return(invisible(TRUE))

--- a/tests/testthat/test-auto.R
+++ b/tests/testthat/test-auto.R
@@ -53,7 +53,7 @@ test_that("dbi (postgres via RPostgreSQL)", {
 
 ## These are not required on CRAN testing, but only for my own
 ## edification.
-if ("redux" %in% .packages(TRUE)) {
+if (can_use_redis()) {
   con <- redux::hiredis()
   storr::test_driver(function(dr = NULL, ...)
     driver_redis_api(dr$prefix %||% rand_str(), con, ...))

--- a/tests/testthat/test-driver-redis-api.R
+++ b/tests/testthat/test-driver-redis-api.R
@@ -1,4 +1,4 @@
-if ("redux" %in% .packages(TRUE)) {
+if (can_use_redis()) {
   context("redis")
   test_that("storr", {
     st <- storr_redis_api(rand_str(), redux::hiredis())


### PR DESCRIPTION
Defined a new function `can_use_redis()` in `helper-storr.R`, used in `test-auto.R` and `test-driver-redis-api.R`. It checks if `redux` is installed and then `redis_available()`. 

To be honest, I am not sure if this solution is correct. I could not get `redux::redis_available()` to return `TRUE` on Ubuntu Linux, Mac OS X, or Windows 7. I have never used `redux` or redis. All I know is that they are related to the reason that `storr` is throwing errors on CRAN.