### PR TITLE
Custom key mangling

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -16,3 +16,5 @@ Rprof\.out
 ^scripts$
 ^vignettes_src$
 ^appveyor\.yml$
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,5 +27,5 @@ Suggests:
     rbenchmark,
     testthat (>= 1.0.0)
 VignetteBuilder: knitr
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.0
 Encoding: UTF-8

--- a/R/driver_remote.R
+++ b/R/driver_remote.R
@@ -16,7 +16,8 @@
 ##'
 ##' @param ... Arguments to pass through to \code{\link{driver_rds}},
 ##'   including \code{compress}, \code{mangle_key},
-##'   \code{mangle_key_pad} and \code{hash_algorithm}.
+##'   \code{mangle_key_pad}, \code{hash_algorithm},
+##'   \code{mangle_key_encode}, and \code{mangle_key_decode}.
 ##'
 ##' @param path_local Path to a local cache.  This can be left as
 ##'   \code{NULL}, in which case a per-session cache will be used.
@@ -134,7 +135,7 @@ R6_driver_remote <- R6::R6Class(
         return(character(0))
       }
       ret <- self$ops$list_dir(path)
-      if (self$rds$mangle_key) decode64(ret, TRUE) else ret
+      if (self$rds$mangle_key) self$rds$mangle_key_decode(ret, TRUE) else ret
     },
 
     ## These functions could be done better if driver_rds takes a

--- a/R/utils.R
+++ b/R/utils.R
@@ -103,6 +103,11 @@ assert_raw <- function(x, name = deparse(substitute(x))) {
   }
 }
 
+assert_function <- function(x, name = deparse(substitute(x))) {
+  if (!is.function(x)) {
+    stop(sprintf("'%s' must be a function", name), call. = FALSE)
+  }
+}
 
 assert_probably_storr_driver <- function(x, name = deparse(substitute(x))) {
   expected <- c("type", "get_hash", "set_hash", "get_object",

--- a/man/driver_remote.Rd
+++ b/man/driver_remote.Rd
@@ -12,7 +12,8 @@ what is required to implement one.}
 
 \item{...}{Arguments to pass through to \code{\link{driver_rds}},
 including \code{compress}, \code{mangle_key},
-\code{mangle_key_pad} and \code{hash_algorithm}.}
+\code{mangle_key_pad}, \code{hash_algorithm},
+\code{mangle_key_encode}, and \code{mangle_key_decode}.}
 
 \item{path_local}{Path to a local cache.  This can be left as
 \code{NULL}, in which case a per-session cache will be used.

--- a/man/storr_rds.Rd
+++ b/man/storr_rds.Rd
@@ -5,11 +5,14 @@
 \alias{driver_rds}
 \title{rds object cache driver}
 \usage{
-storr_rds(path, compress = NULL, mangle_key = NULL, mangle_key_pad = NULL,
-  hash_algorithm = NULL, default_namespace = "objects")
+storr_rds(path, compress = NULL, mangle_key = NULL,
+  mangle_key_pad = NULL, hash_algorithm = NULL,
+  default_namespace = "objects", mangle_key_encode = NULL,
+  mangle_key_decode = NULL)
 
 driver_rds(path, compress = NULL, mangle_key = NULL,
-  mangle_key_pad = NULL, hash_algorithm = NULL)
+  mangle_key_pad = NULL, hash_algorithm = NULL,
+  mangle_key_encode = NULL, mangle_key_decode = NULL)
 }
 \arguments{
 \item{path}{Path for the store.  \code{tempdir()} is a good choice
@@ -38,6 +41,15 @@ values are "md5", "sha1", and others supported by
 
 \item{default_namespace}{Default namespace (see
 \code{\link{storr}}).}
+
+\item{mangle_key_encode}{Optional function for mangling keys.
+Only used if `mangle_key` is `TRUE`.
+Should accept arguments `key` and `pad`.}
+
+\item{mangle_key_decode}{Optional function for unmangling keys.
+Inverse operation of `mangle_key_encode`.
+Only used if `mangle_key` is `TRUE`.
+Should accept arguments `key` and `error`.}
 }
 \description{
 Object cache driver that saves objects using R's native


### PR DESCRIPTION
To follow up on https://github.com/richfitz/storr/issues/88#issuecomment-435656361, this PR proposes custom `mangle_key_encode` and `mangle_key_decode` functions for the RDS driver constructor. It is not quite working yet (I find it difficult to interact with [`test-driver.R`](https://github.com/richfitz/storr/blob/master/inst/spec/test-driver.R)) but does demonstrate what I am proposing.