### PR TITLE
Slight speed improvement in $get_hash() for RDS storrs

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -16,3 +16,5 @@ Rprof\.out
 ^scripts$
 ^vignettes_src$
 ^appveyor\.yml$
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,5 +27,5 @@ Suggests:
     rbenchmark,
     testthat (>= 1.0.0)
 VignetteBuilder: knitr
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.1
 Encoding: UTF-8

--- a/R/driver_rds.R
+++ b/R/driver_rds.R
@@ -189,8 +189,7 @@ R6_driver_rds <- R6::R6Class(
                                                hash_algorithm, "md5", TRUE)
 
       self$hash_length <- nchar(
-        make_hash_serialized_object(self$hash_algorithm, 0L)("")
-      )
+        digest::digest(as.raw(0x00), self$hash_algorithm, serialize = FALSE))
     },
 
     type = function() {

--- a/R/driver_rds.R
+++ b/R/driver_rds.R
@@ -133,6 +133,7 @@ R6_driver_rds <- R6::R6Class(
     mangle_key = NULL,
     mangle_key_pad = NULL,
     hash_algorithm = NULL,
+    hash_length = NULL,
     traits = list(accept = "raw"),
 
     initialize = function(path, compress, mangle_key, mangle_key_pad,
@@ -186,6 +187,10 @@ R6_driver_rds <- R6::R6Class(
       }
       self$hash_algorithm <- driver_rds_config(path, "hash_algorithm",
                                                hash_algorithm, "md5", TRUE)
+
+      self$hash_length <- nchar(
+        make_hash_serialized_object(self$hash_algorithm, 0L)("")
+      )
     },
 
     type = function() {
@@ -197,7 +202,11 @@ R6_driver_rds <- R6::R6Class(
     },
 
     get_hash = function(key, namespace) {
-      readLines(self$name_key(key, namespace))
+      readChar(
+        con = self$name_key(key, namespace),
+        nchars = self$hash_length,
+        useBytes = FALSE
+      )
     },
 
     set_hash = function(key, namespace, hash) {

--- a/R/driver_rds.R
+++ b/R/driver_rds.R
@@ -201,11 +201,7 @@ R6_driver_rds <- R6::R6Class(
     },
 
     get_hash = function(key, namespace) {
-      readChar(
-        con = self$name_key(key, namespace),
-        nchars = self$hash_length,
-        useBytes = FALSE
-      )
+      readChar(self$name_key(key, namespace), self$hash_length, FALSE)
     },
 
     set_hash = function(key, namespace, hash) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,3 +43,7 @@ artifacts:
 
   - path: '\*_*.zip'
     name: Bits
+
+environment:
+  global:
+    USE_RTOOLS: true

--- a/man/storr_rds.Rd
+++ b/man/storr_rds.Rd
@@ -5,8 +5,9 @@
 \alias{driver_rds}
 \title{rds object cache driver}
 \usage{
-storr_rds(path, compress = NULL, mangle_key = NULL, mangle_key_pad = NULL,
-  hash_algorithm = NULL, default_namespace = "objects")
+storr_rds(path, compress = NULL, mangle_key = NULL,
+  mangle_key_pad = NULL, hash_algorithm = NULL,
+  default_namespace = "objects")
 
 driver_rds(path, compress = NULL, mangle_key = NULL,
   mangle_key_pad = NULL, hash_algorithm = NULL)


### PR DESCRIPTION
- Pre-compute the hash length and save it in the `storr` alongside `hash_algorithm`.
- Use `readChar()` instead of `readLines()` in `get_hash()`.
- Benchmarks: https://github.com/richfitz/storr/issues/96#issuecomment-452357226