### PR TITLE
Add functions that R-3.1.0 does not have

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,5 +27,5 @@ Suggests:
     rbenchmark,
     testthat (>= 1.0.0)
 VignetteBuilder: knitr
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.1
 Encoding: UTF-8

--- a/R/utils.R
+++ b/R/utils.R
@@ -179,3 +179,12 @@ file_size <- function(...) {
 prompt_ask_yes_no <- function(reason) {
   utils::menu(c("no", "yes"), FALSE, title = reason) == 2 # nocov
 }
+
+# These functions are not available in R-3.1.0.
+lengths <- function(x, use.names = TRUE) {
+  vapply(x, length, FUN.VALUE = integer(1), USE.NAMES = use.names)
+}
+
+file.size <- function(...) {
+  file.info(..., extra_cols = FALSE)$size
+}

--- a/man/storr_rds.Rd
+++ b/man/storr_rds.Rd
@@ -5,8 +5,9 @@
 \alias{driver_rds}
 \title{rds object cache driver}
 \usage{
-storr_rds(path, compress = NULL, mangle_key = NULL, mangle_key_pad = NULL,
-  hash_algorithm = NULL, default_namespace = "objects")
+storr_rds(path, compress = NULL, mangle_key = NULL,
+  mangle_key_pad = NULL, hash_algorithm = NULL,
+  default_namespace = "objects")
 
 driver_rds(path, compress = NULL, mangle_key = NULL,
   mangle_key_pad = NULL, hash_algorithm = NULL)


### PR DESCRIPTION
Functions `lengths()` and `file.size()` did not exist in R-3.1.0, so I just added the appropriate one-liners in `util.R`. This fixes many, but not all, of the tests on R-3.1.0. Ref: #99.