### PR TITLE
Optionally avoid scratch

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## storr 1.2.2 (2018-??-??)
 
 * Speed up the `$get_hash()` method of RDS drivers using C code and traits (#96, #98, @wlandau).
+* Allow users to bypass scratch in RDS `storr`s (#116, @wlandau).
 
 ## storr 1.2.1 (2018-10-18)
 

--- a/tests/testthat/test-driver-rds.R
+++ b/tests/testthat/test-driver-rds.R
@@ -381,3 +381,11 @@ test_that("avoid race condition when writing in parallel", {
   ok <- vlapply(1:10, function(i) racy_write())
   expect_true(all(ok))
 })
+
+test_that("use_scratch = FALSE (#116)", {
+  st <- storr_rds(tempfile(), use_scratch = FALSE)
+  st$set("a", "a")
+  expect_equal(st$get("a"), "a")
+  expect_null(st$driver$path_scratch)
+  expect_false(st$driver$use_scratch)
+})


### PR DESCRIPTION
As mentioned in #80, some use cases of RDS `storr`s require atomic writes, which depend on the `scratch` directory. However, writing to scratch and then moving the file creates a bottleneck on some systems, Windows in particular. [This workflow](https://github.com/wlandau/drake-examples/blob/master/overhead/static.R) spends a lot of time renaming tiny files, and the total runtime was around 104 seconds on my machine.

![before-104s](https://user-images.githubusercontent.com/1580860/70020619-532eba80-155b-11ea-8e1b-fd077f3ef690.PNG)

The changes in this PR cut the total runtime down to about 50 seconds, and `file.rename()` is no longer a bottleneck.

![after-50s](https://user-images.githubusercontent.com/1580860/70020642-65a8f400-155b-11ea-8595-8891b895e4ce.PNG)

I need to do more digging to make sure people can disable `scratch` with `drake`, but since progress logging is different than it once was, I think it is worth a shot.

```r
> sessionInfo()
R version 3.6.1 (2019-07-05)
Platform: x86_64-w64-mingw32/x64 (64-bit)
Running under: Windows >= 8 x64 (build 9200)

Matrix products: default

locale:
[1] LC_COLLATE=English_United States.1252  LC_CTYPE=English_United States.1252   
[3] LC_MONETARY=English_United States.1252 LC_NUMERIC=C                          
[5] LC_TIME=English_United States.1252    

attached base packages:
[1] stats     graphics  grDevices utils     datasets  methods   base     

other attached packages:
[1] withr_2.1.2          tibble_2.1.3         storr_1.2.2          microbenchmark_1.4-7
[5] MakefileR_1.0        profile_1.0          fs_1.3.1             drake_7.7.0.9002    

loaded via a namespace (and not attached):
 [1] Rcpp_1.0.3      txtq_0.2.0      crayon_1.3.4    digest_0.6.23   R6_2.4.1       
 [6] backports_1.1.5 magrittr_1.5    pillar_1.4.2    rlang_0.4.2     rstudioapi_0.10
[11] filelock_1.0.2  tools_3.6.1     igraph_1.2.4.2  yaml_2.2.0      compiler_3.6.1 
[16] pkgconfig_2.0.3 base64url_1.4  
```

