### PR TITLE
Faster clear() method for RDS storrs and drivers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## storr 1.2.2 (2018-??-??)
 
 * Speed up the `$get_hash()` method of RDS drivers using C code and traits (#96, #98, @wlandau).
+* Speed up the `$clear()` method of RDS drivers using `unlink(recursive = TRUE)` rather than deleting keys one by one from R. For RDS drivers and `storr`s, the return value of `$clear()` is now `integer(0)` instead of the number of deleted keys (#121, @wlandau).
 
 ## storr 1.2.1 (2018-10-18)
 

--- a/R/driver_rds.R
+++ b/R/driver_rds.R
@@ -295,6 +295,15 @@ R6_driver_rds <- R6::R6Class(
         key <- encode64(key, pad = self$mangle_key_pad)
       }
       file.path(self$path, "keys", namespace, key)
+    },
+    
+    clear = function(namespace) {
+      if (is.null(namespace)) {
+        lapply(self$list_namespaces(), self$clear)
+      } else {
+        unlink(file.path(self$path, "keys", namespace), recursive = TRUE)
+      }
+      invisible(integer(0))
     }
   ))
 

--- a/R/storr.R
+++ b/R/storr.R
@@ -201,6 +201,9 @@ R6_storr <- R6::R6Class(
     },
 
     clear = function(namespace = self$default_namespace) {
+      if (is.function(self$driver$clear)) {
+        return(invisible(self$driver$clear(namespace = namespace)))
+      }
       if (is.null(namespace)) {
         invisible(sum(viapply(self$list_namespaces(), self$clear)))
       } else {

--- a/inst/spec/test-storr.R
+++ b/inst/spec/test-storr.R
@@ -150,19 +150,23 @@ testthat::test_that("clear", {
   st$set("b1", 1, namespace = "b")
 
   testthat::expect_equal(sort(st$list("a")), sort(c("a1", "a2")))
-  testthat::expect_equal(st$clear("a"), 2L)
+  st$clear("a")
   testthat::expect_equal(st$list("a"), character(0))
 
   testthat::expect_equal(st$list("b"), "b1")
-  testthat::expect_equal(st$clear(NULL), 1L)
+  st$clear(NULL)
   testthat::expect_equal(st$list("b"), character(0))
 
   st$set("a1", 1, namespace = "a")
   st$set("a2", 2, namespace = "a")
   st$set("b1", 1, namespace = "b")
-  testthat::expect_equal(st$clear(NULL), 3L)
-  testthat::expect_equal(st$clear(NULL), 0L)
-  testthat::expect_equal(st$clear("no_such_namespace"), 0L)
+  testthat::expect_equal(sort(st$list("a")), sort(c("a1", "a2")))
+  testthat::expect_equal(st$list("b"), "b1")
+  st$clear(NULL)
+  testthat::expect_equal(st$list("a"), character(0))
+  testthat::expect_equal(st$list("b"), character(0))
+  testthat::expect_silent(tmp <- st$clear(NULL))
+  testthat::expect_silent(tmp <- st$clear("no_such_namespace"))
 })
 
 


### PR DESCRIPTION
This PR implements the original proposal in https://github.com/richfitz/storr/issues/121#issue-579314857.

## Changes

1. The RDS driver now has a `clear()` method, which uses `unlink(recursive = TRUE)` instead of deleting keys one by one from R.
2. The `clear()` method in the `storr` base class looks for a driver's `clear()` method first, then defaults to deleting keys one by one if the driver has no such method.
3. The return value of `clear()` in RDS drivers is `integer(0)` instead of the number of deleted keys.
4. Tests updated to reflect (3).

## Benchmarks

We see the speed improvements we expected from https://github.com/richfitz/storr/issues/121#issue-579314857.

``` r
library(storr)
init_storr <- function() {
  s <- storr_rds(tempfile())
  keys <- as.character(seq_len(2))
  values <- rep(TRUE, length(keys))
  s$mset(keys, values)
  s
}

s <- init_storr()
system.time(s$clear())
#>    user  system elapsed 
#>   0.000   0.000   0.001
```

<sup>Created on 2020-03-15 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
