### PR TITLE
Don't use start_end_reporter argument in testthat 3.0.0

### DIFF
--- a/R/spec.R
+++ b/R/spec.R
@@ -76,8 +76,15 @@ test_driver <- function(create) {
   dr$destroy()
 
   env$.driver_create <- create
-  res <- lapply(files, testthat::test_file, env = env,
-                reporter = reporter, start_end_reporter = FALSE)
+
+  if (packageVersion("testthat") < "2.99") {
+    res <- lapply(files, testthat::test_file, env = env,
+                  reporter = reporter, start_end_reporter = FALSE)
+
+  } else {
+    res <- lapply(files, testthat::test_file, env = env,
+                  reporter = reporter)
+  }
 
   df <- do.call("rbind", lapply(res, as.data.frame))
 


### PR DESCRIPTION
This is technically a breaking change in testthat, but so few packages (i.e. just storrr out of ~3000 packages tested so far), I'd prefer to just break the API if you don't mind accepting this PR.